### PR TITLE
Support multiple concurrent sessions

### DIFF
--- a/src/steroids.coffee
+++ b/src/steroids.coffee
@@ -1,5 +1,7 @@
+global.Promise = require("bluebird")
+global.argv = require('optimist').argv
+
 path = require "path"
-argv = require('optimist').argv
 util = require "util"
 open = require "open"
 fs = require "fs"
@@ -8,7 +10,6 @@ chalk = require "chalk"
 Help = require "./steroids/Help"
 paths = require "./steroids/paths"
 
-global.Promise = require("bluebird")
 Promise.onPossiblyUnhandledRejection (e, promise) ->
   throw e
 

--- a/src/steroids/paths.coffee
+++ b/src/steroids/paths.coffee
@@ -123,7 +123,7 @@ class Paths
 
   @userHome: if process.platform == 'win32' then process.env.USERPROFILE else process.env.HOME
   @storedSettings: path.join @userHome, ".appgyver"
-  @oauthTokenPath: path.join @storedSettings, "token.json"
+  @oauthTokenPath: global.argv.oauthTokenPath ? path.join @storedSettings, "token.json"
 
   @rippleBinary: path.join @npm, "node_modules", "ripple-emulator", "bin", "ripple"
 


### PR DESCRIPTION
Implements support for multiple concurrent sessions by allowing the user to choose which session storage file is used per each `steroids` command with the `oauthTokenFile` flag.

We can login with a non-default path:

    λ  ~  steroids login --oauthTokenPath=$HOME/.appgyver/sikrit

      Success, you have been logged in.

And logout using that same path:

    λ  ~  steroids logout --oauthTokenPath=$HOME/.appgyver/sikrit

      You have been logged out.

While our default session is still in place:

    λ  ~  steroids login

    4 May 17:39:07 - Already logged in.