### PR TITLE
Changes to stop steroids from continuously building when file is changed

### DIFF
--- a/src/steroids/connect.coffee
+++ b/src/steroids/connect.coffee
@@ -181,10 +181,6 @@ class Connect
 
       maker = =>
         return if isMaking
-        
-
-        console.log "isMaking " + isMaking
-        
         isMaking = true
 
         steroidsCli.log
@@ -199,17 +195,14 @@ class Connect
             doFullReload()
         .then =>
           isMaking = false
-        console.log "value if should Make" + shouldMake  
 
       
 
       appWatcher.on ["add", "change", "unlink"], (path)=>
-        console.log "Change detected in app"
         maker();
         return;
 
       wwwWatcher.on ["add", "change", "unlink"], (path)=>
-        console.log "Change detected in www folder"
         maker();
         return;
 

--- a/src/steroids/connect.coffee
+++ b/src/steroids/connect.coffee
@@ -181,9 +181,10 @@ class Connect
 
       maker = =>
         return if isMaking
-        return unless shouldMake
+        
 
-        shouldMake = false
+        console.log "isMaking " + isMaking
+        
         isMaking = true
 
         steroidsCli.log
@@ -198,18 +199,24 @@ class Connect
             doFullReload()
         .then =>
           isMaking = false
+        console.log "value if should Make" + shouldMake  
 
-      setInterval maker, 100
+      
 
       appWatcher.on ["add", "change", "unlink"], (path)=>
-        shouldMake = true
+        console.log "Change detected in app"
+        maker();
+        return;
 
       wwwWatcher.on ["add", "change", "unlink"], (path)=>
-        shouldMake = true
+        console.log "Change detected in www folder"
+        maker();
+        return;
 
       configWatcher.on ["add", "change", "unlink"], (path)=>
         canBeLiveReload = false
-        shouldMake = true
+        maker();
+        return;
 
       userPaths = if steroidsCli.options.argv.watch
         [].concat(steroidsCli.options.argv.watch)
@@ -223,7 +230,8 @@ class Connect
             ignored: @watchExclude
 
           watcher.on ["add", "change", "unlink"], (path)=>
-            shouldMake = true
+            maker();
+            return;
 
       resolve()
 


### PR DESCRIPTION
When we do steroids connect, steroids calls all the related tasks and our app is loaded, but when we make changes in any file, it continously keeps on loading on the console. I guess the problem is with using setInterval which keeps on calling the maker methods and also with the shouldMake flag used