### PR TITLE
Regex to allow Xcode versions 6 and 7

### DIFF
--- a/src/steroids/Simulator.coffee
+++ b/src/steroids/Simulator.coffee
@@ -31,7 +31,7 @@ class Simulator
 
   validXCodeVersion: ->
     new Promise (resolve, reject) ->
-      minimumXcodeVersion = /Xcode 6./
+      minimumXcodeVersion = /Xcode (6|7)./
 
       xcodeVersionSession = sbawn
         cmd: "xcodebuild"


### PR DESCRIPTION
Self-explanatory. Allowing users to start using Xcode 7 right away (I can confirm Steroids works with Xcode 7 simulators).